### PR TITLE
do not use full ads library

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,5 +49,5 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
-    implementation "com.google.android.gms:play-services-ads:19.4.0"
+    implementation "com.google.android.gms:play-services-ads-identifier:19.4.0"
 }


### PR DESCRIPTION
requesting ads library also requires an AdMob id which causes failures if not provided.