### PR TITLE
Added null check to getMessage call in error case for Android

### DIFF
--- a/android/src/main/java/com/sparkfabrik/capacitor/idfa/Idfa.java
+++ b/android/src/main/java/com/sparkfabrik/capacitor/idfa/Idfa.java
@@ -21,7 +21,7 @@ public class Idfa extends Plugin {
             ret.put("id", info.getId());
             ret.put("isAdTrackingLimited", info.isLimitAdTrackingEnabled());
         } catch (Exception e) {
-            Log.e("Idfa", e.getMessage());
+            Log.e("Idfa", e.getMessage() != null ? e.getMessage() : "Error getting aaid.");
             call.reject("Error getting aaid.", e);
         }
         call.resolve(ret);


### PR DESCRIPTION
This fixes an issue inside the error callback of Android. As Log.e()... cannot handle a null parameter, I added a check to it. I saw this exception inside our firebase crashlytics console.