### PR TITLE
fix: use cjs as main target to resolve jest ReferenceError

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sparkfabrik/capacitor-plugin-idfa",
   "version": "4.0.2",
   "description": "Get native IDFA or Advertising ID from iOS or Android device.",
-  "main": "dist/plugin.js",
+  "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "scripts": {


### PR DESCRIPTION
It resolves a jest Issue - ReferenceError: capacitorExports is not defined.

```typescript
    ReferenceError: capacitorExports is not defined

      1 | import { Injectable } from '@angular/core';
    > 2 | import { AdvertisingInfoResponse, Idfa } from '@sparkfabrik/capacitor-plugin-idfa';
        | ^
```
The same problem https://github.com/capacitor-community/barcode-scanner/issues/67  in the barcode-scanner plugin was resolved this way.


